### PR TITLE
Add Dust2-style map with wall collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A fast-paced first-person shooter game built with React, TypeScript, and HTML5 C
 ## 🎮 Features
 
 - **Smooth FPS Gameplay**: 60fps browser-based first-person shooter
+- **Dust2-Inspired Map**: Navigate basic walls and corridors reminiscent of CS:GO's Dust2
 - **Progressive Difficulty**: Waves get harder with more and faster enemies
 - **Local Leaderboard**: Track your high scores locally
 - **Immersive Audio**: Synthesized sound effects powered by the Web Audio API


### PR DESCRIPTION
## Summary
- sketch Dust2-inspired wall layout and integrate into game state
- block player and enemies on walls and render simple corridors
- document new map feature in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a5d97a588832caec716de67742435